### PR TITLE
Make the tests adaptable to cairo linked with different versions of libpng

### DIFF
--- a/test/test_pkg_config.rb
+++ b/test/test_pkg_config.rb
@@ -44,7 +44,7 @@ class PkgConfigTest < Test::Unit::TestCase
 
     @cairo_png.msvc_syntax = true
     result = pkg_config("cairo-png", "--libs-only-l")
-    msvc_result = result.gsub(/-l(cairo|png12)\b/, '\1.lib')
+    msvc_result = result.gsub(/-l(cairo|png[0-9]+)\b/, '\1.lib')
     assert_not_equal(msvc_result, result)
     assert_equal(msvc_result, @cairo_png.libs_only_l)
   end


### PR DESCRIPTION
Hi,
your tests didn't cover the possibility of cairo linked with a new version of libpng. In Fedora rawhide, it is 15, so I made this pullrequest, that should provide the adaptability for any version of libpng.

Hope you like it :)
