### PR TITLE
Add XQuartz's path for X11

### DIFF
--- a/lib/pkg-config.rb
+++ b/lib/pkg-config.rb
@@ -285,6 +285,7 @@ class PackageConfig
                     "/usr/lib64/pkgconfig",
                     "/usr/lib/pkgconfig",
                     "/usr/X11/lib/pkgconfig/",
+                    "/opt/X11/lib/pkgconfig/",
                     "/usr/share/pkgconfig"].join(SEPARATOR)
     libdir = ENV["PKG_CONFIG_LIBDIR"]
     default_path = [libdir, default_path].join(SEPARATOR) if libdir


### PR DESCRIPTION
Because it seems that /usr/X11 has been unused since OS X 10.7.
XQuartz (/opt/X11) is a substitute for /usr/X11.
