### PR TITLE
Fix a typo

### DIFF
--- a/lib/pkg-config.rb
+++ b/lib/pkg-config.rb
@@ -386,7 +386,7 @@ class PackageConfig
 
   IDENTIFIER_RE = /[a-zA-Z\d_\.]+/
   def parse_pc
-    raise NotFoundError ".pc for #{@name} doesn't exist." unless exist?
+    raise NotFoundError, ".pc for #{@name} doesn't exist." unless exist?
     @variables = {}
     @declarations = {}
     File.open(pc_path) do |input|


### PR DESCRIPTION
Fix a typo.

Maybe we should add some test code...

```ruby
  def test_pkg_notfound
    assert_raise(PackageConfig::NotFoundError){PKGConfig.variable('abracadabra', 'sopath')}
  end
```