### PR TITLE
Add support for "<" and ">" operator in "Requires:"

### DIFF
--- a/lib/pkg-config.rb
+++ b/lib/pkg-config.rb
@@ -520,7 +520,7 @@ class PackageConfig
 
   def parse_requires(requires)
     return [] if requires.nil?
-    requires_without_version = requires.gsub(/[<>]?=\s*[\d.a-zA-Z_-]+\s*/, "")
+    requires_without_version = requires.gsub(/(<|>|<=|>=|=)\s*[\d.a-zA-Z_-]+\s*/, "")
     requires_without_version.split(/[,\s]+/)
   end
 

--- a/lib/pkg-config.rb
+++ b/lib/pkg-config.rb
@@ -520,7 +520,7 @@ class PackageConfig
 
   def parse_requires(requires)
     return [] if requires.nil?
-    requires_without_version = requires.gsub(/(<|>|<=|>=|=)\s*[\d.a-zA-Z_-]+\s*/, "")
+    requires_without_version = requires.gsub(/(?:<|>|<=|>=|=)\s*[\d.a-zA-Z_-]+\s*/, "")
     requires_without_version.split(/[,\s]+/)
   end
 

--- a/test/test-pkg-config.rb
+++ b/test/test-pkg-config.rb
@@ -233,29 +233,34 @@ class PkgConfigTest < Test::Unit::TestCase
       @cairo.__send__(:parse_requires, requires)
     end
 
-    def test_greater_than_or_equals_to_version
+    def test_broken_version
       assert_equal(["fribidi"],
                    parse_requires("fribidi >= fribidi_required_dep"))
     end
-
-    def test_greater_than_version
+  
+    def test_greater_than_or_equals_to
       assert_equal(["fribidi"],
-                   parse_requires("fribidi > fribidi_required_dep"))
+                   parse_requires("fribidi >= 1.0"))
     end
 
-    def test_less_than_or_equals_to_version
+    def test_greater_than
       assert_equal(["fribidi"],
-                   parse_requires("fribidi <= fribidi_required_dep"))
+                   parse_requires("fribidi > 1.0"))
     end
 
-    def test_less_than_version
+    def test_less_than_or_equals_to
       assert_equal(["fribidi"],
-                   parse_requires("fribidi < fribidi_required_dep"))
+                   parse_requires("fribidi <= 1.0"))
     end
 
-    def test_equals_to_version
+    def test_less_than
       assert_equal(["fribidi"],
-                   parse_requires("fribidi = fribidi_required_dep"))
+                   parse_requires("fribidi < 1.0"))
+    end
+
+    def test_equals_to
+      assert_equal(["fribidi"],
+                   parse_requires("fribidi = 1.0"))
     end
   end
 end

--- a/test/test-pkg-config.rb
+++ b/test/test-pkg-config.rb
@@ -233,9 +233,29 @@ class PkgConfigTest < Test::Unit::TestCase
       @cairo.__send__(:parse_requires, requires)
     end
 
-    def test_broken_version
+    def test_greater_than_or_equals_to_version
       assert_equal(["fribidi"],
                    parse_requires("fribidi >= fribidi_required_dep"))
+    end
+
+    def test_greater_than_version
+      assert_equal(["fribidi"],
+                   parse_requires("fribidi > fribidi_required_dep"))
+    end
+
+    def test_less_than_or_equals_to_version
+      assert_equal(["fribidi"],
+                   parse_requires("fribidi <= fribidi_required_dep"))
+    end
+
+    def test_less_than_version
+      assert_equal(["fribidi"],
+                   parse_requires("fribidi < fribidi_required_dep"))
+    end
+
+    def test_equals_to_version
+      assert_equal(["fribidi"],
+                   parse_requires("fribidi = fribidi_required_dep"))
     end
   end
 end


### PR DESCRIPTION
https://people.freedesktop.org/~dbn/pkg-config-guide.html#concepts
> Requires: A list of packages required by this package. The versions of these packages may be specified using the comparison operators =, <, >, <= or >=.