### PR TITLE
Detect homebrew prefix path to fix search without pkg-config installed

### DIFF
--- a/lib/pkg-config.rb
+++ b/lib/pkg-config.rb
@@ -343,6 +343,11 @@ class PackageConfig
             homebrew_repository_candidates <<
               Pathname(homebrew_repository.strip)
           end
+          homebrew_prefix = run_command("brew", "--prefix")
+          if homebrew_prefix
+            homebrew_repository_candidates <<
+              Pathname(homebrew_prefix.strip)
+          end
         end
         homebrew_repository_candidates.uniq.each do |candidate|
           mac_pkgconfig_base_path =


### PR DESCRIPTION
This is `/opt/homebrew` on most macs, which combines just below with `lib/pkgconfig` to get `/opt/homebrew/lib/pkgconfig` in the search paths, which is where all installed & linked homebrew pkgconfig files live.

---

Hi!  I had some trouble installing `iruby` with `rubygems-requirements-system` on a new Mac, where the homebrew install of libzmq was triggered and returned success (exit code 0), but there was still an unclear failure in the gem install.  I traced that to the pkg-config check just after the install:

```
Warning: zeromq 4.3.5_2 is already installed and up-to-date.
To reinstall 4.3.5_2, run:
  brew reinstall zeromq
INFO:  requirements: system: zmq: install: succeeded
ERROR:  Error installing iruby:
	pre-install hook at /Users/meredith.howard/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/rubygems-requirements-system-0.1.1/lib/rubygems_plugin.rb:16 failed for iruby-0.8.2
```

This doesn't happen if you have installed `pkgconf` through homebrew, but I can see the pkg-config executable is not intended to be required.  I saw that pkg-config was vendored and came here to submit a patch -- the other gem is slightly out of date, but even `main` here wasn't working for me without `pkg-config` available.

This PR adds the right path, based on `brew --prefix`, for installed homebrew packages.  The most recent change in this section looks like it tests `/opt/homebrew/Homebrew/lib/pkgconfig` which doesn't exist.

```
❯ which pkg-config                                                                  pkg-config/git/main
pkg-config not found

❯ irb -Ilib -rpkg-config                                                            pkg-config/git/main
irb(main):001> PKGConfig.package_config('libzmq')
=>
#<PackageConfig:0x000000010b4b3208
 @declarations=nil,
 @msvc_syntax=nil,
 @name="libzmq",
 @options={msvc_syntax: nil, override_variables: {}, paths: []},
 @override_variables={},
 @path_position=nil,
 @paths=["/opt/homebrew/Homebrew/Library/Homebrew/os/mac/pkgconfig/15", "/usr/lib/pkgconfig"],
 @pc_path=nil,
 @variables=nil>
irb(main):002> _.exist?
=> false
irb(main):003> ^D

❯ git switch homebrew-prefix-fix                                                    pkg-config/git/main
Switched to branch 'homebrew-prefix-fix'
Your branch is ahead of 'main' by 1 commit.
  (use "git push" to publish your local commits)

❯ irb -Ilib -rpkg-config                                             pkg-config/git/homebrew-prefix-fix
irb(main):001> PKGConfig.package_config('libzmq')
=>
#<PackageConfig:0x000000012a978f30
 @declarations=nil,
 @msvc_syntax=nil,
 @name="libzmq",
 @options={msvc_syntax: nil, override_variables: {}, paths: []},
 @override_variables={},
 @path_position=nil,
 @paths=
  ["/opt/homebrew/Homebrew/Library/Homebrew/os/mac/pkgconfig/15", "/opt/homebrew/lib/pkgconfig", "/usr/lib/pkgconfig"],
 @pc_path=nil,
 @variables=nil>
irb(main):002> _.exist?
=> true
irb(main):003> ^D
```