### PR TITLE
Add mergeback for -D and -W cflags to match pkgconf behavior

### DIFF
--- a/lib/pkg-config.rb
+++ b/lib/pkg-config.rb
@@ -534,7 +534,7 @@ class PackageConfig
       cflags_set << package.declaration("Cflags")
     end
     all_cflags = normalize_cflags(Shellwords.split(cflags_set.join(" ")))
-    path_flags, cflags = all_cflags.partition {|flag| /\A-I/ =~ flag}
+    path_flags, other_flags = all_cflags.partition {|flag| /\A-I/ =~ flag}
     path_flags = path_flags.collect {|flag| normalize_path_flag(flag, "-I")}
     path_flags = path_flags.reject do |flag|
       flag == "-I/usr/include"
@@ -545,8 +545,8 @@ class PackageConfig
         flag.gsub(/\A-I/, "/I")
       end
     end
-    cflags = merge_back_cflags(cflags)
-    [path_flags, cflags]
+    other_flags = merge_back_cflags(other_flags)
+    [path_flags, other_flags]
   end
 
   def normalize_path_flag(path_flag, flag_option)

--- a/lib/pkg-config.rb
+++ b/lib/pkg-config.rb
@@ -534,7 +534,7 @@ class PackageConfig
       cflags_set << package.declaration("Cflags")
     end
     all_cflags = normalize_cflags(Shellwords.split(cflags_set.join(" ")))
-    path_flags, other_flags = all_cflags.partition {|flag| /\A-I/ =~ flag}
+    path_flags, cflags = all_cflags.partition {|flag| /\A-I/ =~ flag}
     path_flags = path_flags.collect {|flag| normalize_path_flag(flag, "-I")}
     path_flags = path_flags.reject do |flag|
       flag == "-I/usr/include"
@@ -545,8 +545,8 @@ class PackageConfig
         flag.gsub(/\A-I/, "/I")
       end
     end
-    other_flags = mergeback_flags(other_flags)
-    [path_flags, other_flags]
+    cflags = merge_back_cflags(cflags)
+    [path_flags, cflags]
   end
 
   def normalize_path_flag(path_flag, flag_option)
@@ -584,17 +584,17 @@ class PackageConfig
   # This is not a complete reproduction yet, but the goal is to stay compatible.
   # https://github.com/pkgconf/pkgconf/blob/pkgconf-2.5.1/libpkgconf/fragment.c#L381-L416
   #
-  # NOTE: This may be slow because this checks mergebacked_flags N times (where
+  # NOTE: This may be slow because this checks merge_back_cflags N times (where
   # N is the number of mergeable flags).
-  def mergeback_flags(flags)
-    mergebacked_flags = []
-    flags.each do |flag|
-      if mergeable_flag?(flag)
-        mergebacked_flags.delete(flag)
+  def merge_back_cflags(cflags)
+    mergebacked_cflags = []
+    cflags.each do |cflag|
+      if mergeable_flag?(cflag)
+        mergebacked_cflags.delete(cflag)
       end
-      mergebacked_flags << flag
+      mergebacked_cflags << cflag
     end
-    mergebacked_flags
+    mergebacked_cflags
   end
 
   def mergeable_flag?(flag)

--- a/lib/pkg-config.rb
+++ b/lib/pkg-config.rb
@@ -545,6 +545,7 @@ class PackageConfig
         flag.gsub(/\A-I/, "/I")
       end
     end
+    other_flags = mergeback_flags(other_flags)
     [path_flags, other_flags]
   end
 
@@ -577,6 +578,27 @@ class PackageConfig
     rescue StopIteration
     end
     normalized_cflags
+  end
+
+  def mergeback_flags(flags)
+    mergebacked_flags = []
+    flags.each do |flag|
+      if mergeable_flag?(flag)
+        mergebacked_flags.delete(flag)
+      end
+      mergebacked_flags << flag
+    end
+    mergebacked_flags
+  end
+
+  def mergeable_flag?(flag)
+    return false unless flag.start_with?("-")
+    return true if flag.start_with?("-D")
+    if flag.start_with?("-W")
+      return false if flag.start_with?("-Wa,", "-Wl,", "-Wp,")
+      return true
+    end
+    false
   end
 
   def collect_libs

--- a/lib/pkg-config.rb
+++ b/lib/pkg-config.rb
@@ -583,6 +583,9 @@ class PackageConfig
   # Implementing behavior compatible with pkgconf's pkgconf_fragment_copy().
   # This is not a complete reproduction yet, but the goal is to stay compatible.
   # https://github.com/pkgconf/pkgconf/blob/pkgconf-2.5.1/libpkgconf/fragment.c#L381-L416
+  #
+  # NOTE: This may be slow because this checks mergebacked_flags N times (where
+  # N is the number of mergeable flags).
   def mergeback_flags(flags)
     mergebacked_flags = []
     flags.each do |flag|

--- a/lib/pkg-config.rb
+++ b/lib/pkg-config.rb
@@ -584,16 +584,16 @@ class PackageConfig
   # This is not a complete reproduction yet, but the goal is to stay compatible.
   # https://github.com/pkgconf/pkgconf/blob/pkgconf-2.5.1/libpkgconf/fragment.c#L381-L416
   def merge_back_cflags(cflags)
-    mergebacked_cflags = []
+    merge_backed_cflags = []
     cflags.each do |cflag|
       if mergeable_flag?(cflag)
         # NOTE: This may be slow because this checks merge_back_cflags N times
         # (where N is the number of mergeable flags).
-        mergebacked_cflags.delete(cflag)
+        merge_backed_cflags.delete(cflag)
       end
-      mergebacked_cflags << cflag
+      merge_backed_cflags << cflag
     end
-    mergebacked_cflags
+    merge_backed_cflags
   end
 
   def mergeable_flag?(flag)

--- a/lib/pkg-config.rb
+++ b/lib/pkg-config.rb
@@ -583,13 +583,12 @@ class PackageConfig
   # Implementing behavior compatible with pkgconf's pkgconf_fragment_copy().
   # This is not a complete reproduction yet, but the goal is to stay compatible.
   # https://github.com/pkgconf/pkgconf/blob/pkgconf-2.5.1/libpkgconf/fragment.c#L381-L416
-  #
-  # NOTE: This may be slow because this checks merge_back_cflags N times (where
-  # N is the number of mergeable flags).
   def merge_back_cflags(cflags)
     mergebacked_cflags = []
     cflags.each do |cflag|
       if mergeable_flag?(cflag)
+        # NOTE: This may be slow because this checks merge_back_cflags N times
+        # (where N is the number of mergeable flags).
         mergebacked_cflags.delete(cflag)
       end
       mergebacked_cflags << cflag

--- a/lib/pkg-config.rb
+++ b/lib/pkg-config.rb
@@ -580,6 +580,9 @@ class PackageConfig
     normalized_cflags
   end
 
+  # Implementing behavior compatible with pkgconf's pkgconf_fragment_copy().
+  # This is not a complete reproduction yet, but the goal is to stay compatible.
+  # https://github.com/pkgconf/pkgconf/blob/pkgconf-2.5.1/libpkgconf/fragment.c#L381-L416
   def mergeback_flags(flags)
     mergebacked_flags = []
     flags.each do |flag|

--- a/test/test-pkg-config.rb
+++ b/test/test-pkg-config.rb
@@ -320,25 +320,25 @@ Cflags: -I${includedir}/my-package
       @glib.__send__(:merge_back_cflags, cflags)
     end
 
-    def test_d_flag
+    def test_d
       assert_equal(["-DFOO"],
                    merge_back_cflags(["-DFOO", "-DFOO"]))
     end
 
-    def test_w_flag
+    def test_w
       assert_equal(["-Wno-unknown-warning-option"],
                    merge_back_cflags(["-Wno-unknown-warning-option",
                                       "-Wno-unknown-warning-option"]))
     end
 
-    def test_wa_wl_wp_flags_not_merged_back
+    def test_wa_wl_wp
       assert_equal(["-Wa,--noexecstack", "-Wl,--as-needed", "-Wp,-DFOO",
                     "-Wa,--noexecstack", "-Wl,--as-needed", "-Wp,-DFOO"],
                    merge_back_cflags(["-Wa,--noexecstack", "-Wl,--as-needed", "-Wp,-DFOO",
                                       "-Wa,--noexecstack", "-Wl,--as-needed", "-Wp,-DFOO"]))
     end
 
-    def test_mixed_flags
+    def test_mixed
       assert_equal(["-Wl,--as-needed", "-DFOO", "-Wall", "-Wl,--as-needed"],
                    merge_back_cflags(["-DFOO", "-Wall", "-Wl,--as-needed",
                                       "-DFOO", "-Wall", "-Wl,--as-needed"]))

--- a/test/test-pkg-config.rb
+++ b/test/test-pkg-config.rb
@@ -315,126 +315,33 @@ Cflags: -I${includedir}/my-package
     end
   end
 
-  sub_test_case("cflags mergeback") do
-    def create_pc_file(name, content)
-      pc_dir = File.join(@tmpdir, "pkgconfig")
-      FileUtils.mkdir_p(pc_dir)
-      pc_path = File.join(pc_dir, "#{name}.pc")
-      File.write(pc_path, content)
-      pc_dir
+  sub_test_case("#merge_back_cflags") do
+    def merge_back_cflags(cflags)
+      @glib.__send__(:merge_back_cflags, cflags)
     end
 
-    def setup
-      PackageConfig.clear_configure_args_cache
-      @tmpdir = Dir.mktmpdir
+    def test_d_flag
+      assert_equal(["-DFOO"],
+                   merge_back_cflags(["-DFOO", "-DFOO"]))
     end
 
-    def teardown
-      FileUtils.rm_rf(@tmpdir)
+    def test_w_flag
+      assert_equal(["-Wno-unknown-warning-option"],
+                   merge_back_cflags(["-Wno-unknown-warning-option",
+                                      "-Wno-unknown-warning-option"]))
     end
 
-    def test_d_flag_mergeback
-      pc_dir = create_pc_file("main-package", <<-PC)
-prefix=/usr/local
-includedir=${prefix}/include
-
-Name: main-package
-Description: Main package for testing
-Version: 1.0.0
-Requires: dep-package
-Cflags: -I${includedir}/main -DFOO
-      PC
-      create_pc_file("dep-package", <<-PC)
-prefix=/usr/local
-includedir=${prefix}/include
-
-Name: dep-package
-Description: Dependency package
-Version: 1.0.0
-Cflags: -I${includedir}/dep -DFOO
-      PC
-      package = PackageConfig.new("main-package", paths: [pc_dir])
-      assert_equal("-I/usr/local/include/main -I/usr/local/include/dep -DFOO",
-                   package.cflags)
+    def test_wa_wl_wp_flags_not_merged_back
+      assert_equal(["-Wa,--noexecstack", "-Wl,--as-needed", "-Wp,-DFOO",
+                    "-Wa,--noexecstack", "-Wl,--as-needed", "-Wp,-DFOO"],
+                   merge_back_cflags(["-Wa,--noexecstack", "-Wl,--as-needed", "-Wp,-DFOO",
+                                      "-Wa,--noexecstack", "-Wl,--as-needed", "-Wp,-DFOO"]))
     end
 
-    def test_w_flag_mergeback
-      pc_dir = create_pc_file("main-package", <<-PC)
-prefix=/usr/local
-includedir=${prefix}/include
-
-Name: main-package
-Description: Main package for testing
-Version: 1.0.0
-Requires: dep-package
-Cflags: -I${includedir}/main -Wno-unknown-warning-option
-      PC
-      create_pc_file("dep-package", <<-PC)
-prefix=/usr/local
-includedir=${prefix}/include
-
-Name: dep-package
-Description: Dependency package
-Version: 1.0.0
-Cflags: -I${includedir}/dep -Wno-unknown-warning-option
-      PC
-      package = PackageConfig.new("main-package", paths: [pc_dir])
-      assert_equal("-I/usr/local/include/main -I/usr/local/include/dep " +
-                   "-Wno-unknown-warning-option",
-                   package.cflags)
-    end
-
-    def test_wa_wl_wp_flags_not_mergebacked
-      pc_dir = create_pc_file("main-package", <<-PC)
-prefix=/usr/local
-includedir=${prefix}/include
-
-Name: main-package
-Description: Main package for testing
-Version: 1.0.0
-Requires: dep-package
-Cflags: -I${includedir}/main -Wa,--noexecstack -Wl,--as-needed -Wp,-DFOO
-      PC
-      create_pc_file("dep-package", <<-PC)
-prefix=/usr/local
-includedir=${prefix}/include
-
-Name: dep-package
-Description: Dependency package
-Version: 1.0.0
-Cflags: -I${includedir}/dep -Wa,--noexecstack -Wl,--as-needed -Wp,-DFOO
-      PC
-      package = PackageConfig.new("main-package", paths: [pc_dir])
-      assert_equal("-I/usr/local/include/main -I/usr/local/include/dep " +
-                   "-Wa,--noexecstack -Wl,--as-needed -Wp,-DFOO " +
-                   "-Wa,--noexecstack -Wl,--as-needed -Wp,-DFOO",
-                   package.cflags)
-    end
-
-    def test_mixed_flags_mergeback
-      pc_dir = create_pc_file("main-package", <<-PC)
-prefix=/usr/local
-includedir=${prefix}/include
-
-Name: main-package
-Description: Main package for testing
-Version: 1.0.0
-Requires: dep-package
-Cflags: -I${includedir}/main -DFOO -Wall -Wl,--as-needed
-      PC
-      create_pc_file("dep-package", <<-PC)
-prefix=/usr/local
-includedir=${prefix}/include
-
-Name: dep-package
-Description: Dependency package
-Version: 1.0.0
-Cflags: -I${includedir}/dep -DFOO -Wall -Wl,--as-needed
-      PC
-      package = PackageConfig.new("main-package", paths: [pc_dir])
-      assert_equal("-I/usr/local/include/main -I/usr/local/include/dep " +
-                   "-Wl,--as-needed -DFOO -Wall -Wl,--as-needed",
-                   package.cflags)
+    def test_mixed_flags
+      assert_equal(["-Wl,--as-needed", "-DFOO", "-Wall", "-Wl,--as-needed"],
+                   merge_back_cflags(["-DFOO", "-Wall", "-Wl,--as-needed",
+                                      "-DFOO", "-Wall", "-Wl,--as-needed"]))
     end
   end
 end

--- a/test/test-pkg-config.rb
+++ b/test/test-pkg-config.rb
@@ -314,4 +314,127 @@ Cflags: -I${includedir}/my-package
                    parse_requires("fribidi = 1.0"))
     end
   end
+
+  sub_test_case("cflags mergeback") do
+    def create_pc_file(name, content)
+      pc_dir = File.join(@tmpdir, "pkgconfig")
+      FileUtils.mkdir_p(pc_dir)
+      pc_path = File.join(pc_dir, "#{name}.pc")
+      File.write(pc_path, content)
+      pc_dir
+    end
+
+    def setup
+      PackageConfig.clear_configure_args_cache
+      @tmpdir = Dir.mktmpdir
+    end
+
+    def teardown
+      FileUtils.rm_rf(@tmpdir)
+    end
+
+    def test_d_flag_mergeback
+      pc_dir = create_pc_file("main-package", <<-PC)
+prefix=/usr/local
+includedir=${prefix}/include
+
+Name: main-package
+Description: Main package for testing
+Version: 1.0.0
+Requires: dep-package
+Cflags: -I${includedir}/main -DFOO
+      PC
+      create_pc_file("dep-package", <<-PC)
+prefix=/usr/local
+includedir=${prefix}/include
+
+Name: dep-package
+Description: Dependency package
+Version: 1.0.0
+Cflags: -I${includedir}/dep -DFOO
+      PC
+      package = PackageConfig.new("main-package", paths: [pc_dir])
+      assert_equal("-I/usr/local/include/main -I/usr/local/include/dep -DFOO",
+                   package.cflags)
+    end
+
+    def test_w_flag_mergeback
+      pc_dir = create_pc_file("main-package", <<-PC)
+prefix=/usr/local
+includedir=${prefix}/include
+
+Name: main-package
+Description: Main package for testing
+Version: 1.0.0
+Requires: dep-package
+Cflags: -I${includedir}/main -Wno-unknown-warning-option
+      PC
+      create_pc_file("dep-package", <<-PC)
+prefix=/usr/local
+includedir=${prefix}/include
+
+Name: dep-package
+Description: Dependency package
+Version: 1.0.0
+Cflags: -I${includedir}/dep -Wno-unknown-warning-option
+      PC
+      package = PackageConfig.new("main-package", paths: [pc_dir])
+      assert_equal("-I/usr/local/include/main -I/usr/local/include/dep " +
+                   "-Wno-unknown-warning-option",
+                   package.cflags)
+    end
+
+    def test_wa_wl_wp_flags_not_mergebacked
+      pc_dir = create_pc_file("main-package", <<-PC)
+prefix=/usr/local
+includedir=${prefix}/include
+
+Name: main-package
+Description: Main package for testing
+Version: 1.0.0
+Requires: dep-package
+Cflags: -I${includedir}/main -Wa,--noexecstack -Wl,--as-needed -Wp,-DFOO
+      PC
+      create_pc_file("dep-package", <<-PC)
+prefix=/usr/local
+includedir=${prefix}/include
+
+Name: dep-package
+Description: Dependency package
+Version: 1.0.0
+Cflags: -I${includedir}/dep -Wa,--noexecstack -Wl,--as-needed -Wp,-DFOO
+      PC
+      package = PackageConfig.new("main-package", paths: [pc_dir])
+      assert_equal("-I/usr/local/include/main -I/usr/local/include/dep " +
+                   "-Wa,--noexecstack -Wl,--as-needed -Wp,-DFOO " +
+                   "-Wa,--noexecstack -Wl,--as-needed -Wp,-DFOO",
+                   package.cflags)
+    end
+
+    def test_mixed_flags_mergeback
+      pc_dir = create_pc_file("main-package", <<-PC)
+prefix=/usr/local
+includedir=${prefix}/include
+
+Name: main-package
+Description: Main package for testing
+Version: 1.0.0
+Requires: dep-package
+Cflags: -I${includedir}/main -DFOO -Wall -Wl,--as-needed
+      PC
+      create_pc_file("dep-package", <<-PC)
+prefix=/usr/local
+includedir=${prefix}/include
+
+Name: dep-package
+Description: Dependency package
+Version: 1.0.0
+Cflags: -I${includedir}/dep -DFOO -Wall -Wl,--as-needed
+      PC
+      package = PackageConfig.new("main-package", paths: [pc_dir])
+      assert_equal("-I/usr/local/include/main -I/usr/local/include/dep " +
+                   "-Wl,--as-needed -DFOO -Wall -Wl,--as-needed",
+                   package.cflags)
+    end
+  end
 end


### PR DESCRIPTION
When multiple packages have the same -D or -W flags, pkgconf removes previous occurrences and keeps only the last one (merge back).
This prevents flag duplication like "-DNOMINMAX"
appearing many times.

```console
$ pkgconf --cflags re2
-pthread -DNOMINMAX
$ ruby -r pkg-config -e 'puts PKGConfig.cflags("re2")'
-pthread -DNOMINMAX -DNOMINMAX -DNOMINMAX ...
```

Flags excluded from merge back (kept as duplicates):
- -Wa, (assembler options)
- -Wl, (linker options)
- -Wp, (preprocessor options)

This PR only supports merge back for -D and -W flags. Other flags that pkgconf also merges back are not yet supported.