### PR TITLE
Always add conda dirs to default paths

### DIFF
--- a/lib/pkg-config.rb
+++ b/lib/pkg-config.rb
@@ -363,6 +363,18 @@ class PackageConfig
           paths << pkgconfig_path.to_s if pkgconfig_path.exist?
         end
       end
+      conda_prefixes = []
+      conda_prefixes << ENV["CONDA_PREFIX"] if ENV["CONDA_PREFIX"]
+      if ENV["CONDA_EXE"]
+        conda_base = File.dirname(File.dirname(ENV["CONDA_EXE"]))
+        conda_prefixes << conda_base
+      end
+      conda_prefixes.uniq.each do |prefix|
+        lib_pkgconfig = File.join(prefix, "lib", "pkgconfig")
+        share_pkgconfig = File.join(prefix, "share", "pkgconfig")
+        paths << lib_pkgconfig if File.directory?(lib_pkgconfig)
+        paths << share_pkgconfig if File.directory?(share_pkgconfig)
+      end
       paths.concat(default_paths)
       [
         with_config("pkg-config-path") || ENV["PKG_CONFIG_PATH"],


### PR DESCRIPTION
Related to https://github.com/ruby-gnome/rubygems-requirements-system/pull/27.

When trying to install the red-arrow gem with rubygems-system-requirements, I get a pre-install hook error. That's fixed by https://github.com/ruby-gnome/rubygems-requirements-system/pull/27. But then I also get an extconf error,

```
checking for arrow version (>= 24.0.0)... no (nonexistent)
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.
```

What happened before was that rubygems-system-requiements detected by system had conda on it, installed arrow-glib to my base conda prefix. Then the red-arrow gem's extconfig.rb depends on this gem which doesn't support that case.

This PR unconditionally adds the pkgconfig dirs from conda to the list of default paths, adding both the base dir and the dir from any currently activated envs. This PR along with https://github.com/ruby-gnome/rubygems-requirements-system/pull/27 gets red-arrow installing correctly on my system.